### PR TITLE
Moved definition of mosesdir to a single location

### DIFF
--- a/scripts/create-1.43
+++ b/scripts/create-1.43
@@ -31,11 +31,7 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-#Edit the file 'mt-location' to change $mosesdir and $MMMdir for all scripts.
-source mt-location
-
-#Full path of the already trained corpora (place where trainings are stocked)
-corpora_trained="$mosesdir/corpora_trained"
+#The file 'mt-location' defines $mosesdir and $MMMdir and is called below by `source mt-location`
 
 #Number of processors of your computer that will be used by MGIZA (if you use all the processors available, the training speed will be improve considerably)
 #!!! To use all the cores available in your computer, leave this parameter empty!!!
@@ -96,6 +92,11 @@ megampack=megam_i686.opt
 ####################################################################################
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
+#The file 'mt-location' defines $mosesdir and $MMMdir for all scripts.
+source mt-location
+
+#Full path of the already trained corpora (place where trainings are stocked)
+corpora_trained="$mosesdir/corpora_trained"
 
 startdate=`date +day:%d/%m/%Y-time:%H:%M:%S`
 a=$0

--- a/scripts/create-1.43
+++ b/scripts/create-1.43
@@ -31,11 +31,8 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-# Full path of the base directory of your Moses system (which will be created by this script) 
-mosesdir="$HOME/Desktop/Machine-Translation/MMM"
-
-# Full path of the place where the Moses for Mere Mortals scripts subdirectory is
-MMMdir="$HOME/Desktop/Machine-Translation/Moses-for-Mere-Mortals"
+#Edit the file 'mt-location' to change $mosesdir and $MMMdir for all scripts.
+source mt-location
 
 #Full path of the already trained corpora (place where trainings are stocked)
 corpora_trained="$mosesdir/corpora_trained"

--- a/scripts/create-1.43
+++ b/scripts/create-1.43
@@ -31,7 +31,7 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-#The file 'mt-location' defines $mosesdir and $MMMdir and is called below by `source mt-location`
+#The file 'mt-location' defines $mosesdir and $MMMdir and is called below by the `source` command below
 
 #Number of processors of your computer that will be used by MGIZA (if you use all the processors available, the training speed will be improve considerably)
 #!!! To use all the cores available in your computer, leave this parameter empty!!!
@@ -93,7 +93,7 @@ megampack=megam_i686.opt
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
 #The file 'mt-location' defines $mosesdir and $MMMdir for all scripts.
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 
 #Full path of the already trained corpora (place where trainings are stocked)
 corpora_trained="$mosesdir/corpora_trained"

--- a/scripts/install-0.50
+++ b/scripts/install-0.50
@@ -33,7 +33,7 @@ d1=`date +%s`
 logname=${a##*/}-$d1
 
 pwd="$PWD"
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 report_dir="$mosesdir/reports"
 mkdir -p "$report_dir" 2>/dev/null
 mkdir -p "$mosesdir/logs/install" 2>/dev/null

--- a/scripts/install-0.50
+++ b/scripts/install-0.50
@@ -24,11 +24,6 @@
 # 1) Internet connection (not absolutely necessary)
 # 2) A Ubuntu 12.04 or 14.04 LTS 64-bit environment
 
-#####################################################################################
-# The values of the variables that follow should be filled according to your needs:
-#####################################################################################
-# Full path of the base directory location of your Moses system (it is the directory where this install-0.50 script, and the other scripts, are)
-mosesdir="$HOME/Desktop/Machine-Translation/MMM"
 ####################################################################################
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
@@ -38,6 +33,7 @@ d1=`date +%s`
 logname=${a##*/}-$d1
 
 pwd="$PWD"
+source mt-location
 report_dir="$mosesdir/reports"
 mkdir -p "$report_dir" 2>/dev/null
 mkdir -p "$mosesdir/logs/install" 2>/dev/null

--- a/scripts/make-test-files-0.27
+++ b/scripts/make-test-files-0.27
@@ -79,7 +79,7 @@ done
 }
 
 echo "******* Initialize"
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 #Directory where the source and target language files used for creating the training, tuning and test files are located
 original_files_dir="$mosesdir/corpora_for_training"
 #Directory where the source and target language files created for training, tuning and test files are located

--- a/scripts/make-test-files-0.27
+++ b/scripts/make-test-files-0.27
@@ -25,8 +25,6 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-#Base path of Moses installation
-mosesdir="$HOME/Desktop/Machine-Translation/MMM"
 #Source language abbreviation
 lang1=pt
 #Target language abbreviation
@@ -81,6 +79,7 @@ done
 }
 
 echo "******* Initialize"
+source mt-location
 #Directory where the source and target language files used for creating the training, tuning and test files are located
 original_files_dir="$mosesdir/corpora_for_training"
 #Directory where the source and target language files created for training, tuning and test files are located

--- a/scripts/mt-location
+++ b/scripts/mt-location
@@ -1,3 +1,5 @@
+# This file defines $mosesdir for all scripts.
+
 # Full path of the directory that contains the Moses-for-Mere-Mortals folder
 mtdir="$HOME/Desktop/Machine-Translation"
 
@@ -6,7 +8,8 @@ mtdir="$HOME/Desktop/Machine-Translation"
 # - error checking (does $mtdir exist? etc.)
 # - maybe mtdir=$(readlink -f $(pwd)/../..) 
 # - update script modification dates in comments...version numbers too?
-# - update Chapter 10 of Tutorial.pdf 
+# - update Chapter 10 of Tutorial.pdf
+# - update Chapter 11 of Tutorial.pdf ($mosesdirmine is no longer user-specified) 
 
 
 ####################################################################################
@@ -16,4 +19,9 @@ mtdir="$HOME/Desktop/Machine-Translation"
 mosesdir="$mtdir/MMM"
 
 # Full path of the place where the Moses for Mere Mortals scripts subdirectory is
+# This variable is only used in the create and make-test-files scripts
 MMMdir="$mtdir/Moses-for-Mere-Mortals"
+
+# Base dir of the Moses system (e.g., $HOME/moses-irstlm-randlm) whose trainings you want to transfer to another location
+# This variable is only used in the transfer-training-to-another-location script
+mosesdirmine=$mosesdir

--- a/scripts/mt-location
+++ b/scripts/mt-location
@@ -1,0 +1,19 @@
+# Full path of the directory that contains the Moses-for-Mere-Mortals folder
+mtdir="$HOME/Desktop/Machine-Translation"
+
+# Consolidated to a single location: Don't Repeat Yourself.
+# To-do
+# - error checking (does $mtdir exist? etc.)
+# - maybe mtdir=$(readlink -f $(pwd)/../..) 
+# - update script modification dates in comments...version numbers too?
+# - update Chapter 10 of Tutorial.pdf 
+
+
+####################################################################################
+# DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
+####################################################################################
+# Full path of the base directory of your Moses system (which will be created by this script) 
+mosesdir="$mtdir/MMM"
+
+# Full path of the place where the Moses for Mere Mortals scripts subdirectory is
+MMMdir="$mtdir/Moses-for-Mere-Mortals"

--- a/scripts/score-0.89
+++ b/scripts/score-0.89
@@ -35,7 +35,7 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-#The file 'mt-location' defines $mosesdir for all scripts and is called by `source mt-location` below.
+#The file 'mt-location' defines $mosesdir for all scripts and is called by the `source` command below.
 
 #Number of processors of your computer that will be used by MGIZA (if you use all the processors available, the training will be considerably speeded) 
 #!!! To use all the cores available in your computer, leave this parameter empty!!!
@@ -62,7 +62,7 @@ else
 fi
 
 pwd="$PWD"
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 
 #Directory where Moses translation tools are located
 toolsdir="$mosesdir/tools"

--- a/scripts/score-0.89
+++ b/scripts/score-0.89
@@ -35,6 +35,8 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
+#The file 'mt-location' defines $mosesdir for all scripts and is called by `source mt-location` below.
+
 #Number of processors of your computer that will be used by MGIZA (if you use all the processors available, the training will be considerably speeded) 
 #!!! To use all the cores available in your computer, leave this parameter empty!!!
 cores=

--- a/scripts/score-0.89
+++ b/scripts/score-0.89
@@ -35,9 +35,6 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-#Base directory of your Moses installation (made by the create script)
-mosesdir="$HOME/Desktop/Machine-Translation/MMM"
-
 #Number of processors of your computer that will be used by MGIZA (if you use all the processors available, the training will be considerably speeded) 
 #!!! To use all the cores available in your computer, leave this parameter empty!!!
 cores=
@@ -63,6 +60,7 @@ else
 fi
 
 pwd="$PWD"
+source mt-location
 
 #Directory where Moses translation tools are located
 toolsdir="$mosesdir/tools"

--- a/scripts/train-1.22
+++ b/scripts/train-1.22
@@ -29,7 +29,7 @@
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
 
-#The file 'mt-location' defines $mosesdir for all scripts and is called by `source mt-location` below.
+#The file 'mt-location' defines $mosesdir for all scripts and is called by the `source` command below.
 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #NOTE 1: The corpus that you want to train, together with the respective tuning files (if different), the testing files (if different), the file used for recasing, and the file used to build the language model (if different) should be placed in $mosesdir/corpora_for_training !!!
@@ -425,7 +425,7 @@ fi
 
 echo "****** build name of directories where corpus trained files will be located"
 #The file 'mt-location' defines $mosesdir for all scripts
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 #Full path of the tools directory (giza, irstlm, moses, scripts, ...)
 toolsdir="$mosesdir/tools"
 #Full path of the files used for training (corpus, language model, recaser, tuning, evaluation) 

--- a/scripts/train-1.22
+++ b/scripts/train-1.22
@@ -29,8 +29,8 @@
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
 
-#Full path of the base directory of your Moses system 
-mosesdir="$HOME/Desktop/Machine-Translation/MMM"
+#Edit the file 'mt-location' to change $mosesdir for all scripts.
+source mt-location 
 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #NOTE 1: The corpus that you want to train, together with the respective tuning files (if different), the testing files (if different), the file used for recasing, and the file used to build the language model (if different) should be placed in $mosesdir/corpora_for_training !!!

--- a/scripts/train-1.22
+++ b/scripts/train-1.22
@@ -29,8 +29,7 @@
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
 
-#Edit the file 'mt-location' to change $mosesdir for all scripts.
-source mt-location 
+#The file 'mt-location' defines $mosesdir for all scripts and is called by `source mt-location` below.
 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #NOTE 1: The corpus that you want to train, together with the respective tuning files (if different), the testing files (if different), the file used for recasing, and the file used to build the language model (if different) should be placed in $mosesdir/corpora_for_training !!!
@@ -425,6 +424,8 @@ else
 fi
 
 echo "****** build name of directories where corpus trained files will be located"
+#The file 'mt-location' defines $mosesdir for all scripts
+source mt-location
 #Full path of the tools directory (giza, irstlm, moses, scripts, ...)
 toolsdir="$mosesdir/tools"
 #Full path of the files used for training (corpus, language model, recaser, tuning, evaluation) 

--- a/scripts/transfer-training-to-another-location-0.09
+++ b/scripts/transfer-training-to-another-location-0.09
@@ -25,7 +25,7 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-# The file 'mt-location' defines $mosesdirmine and is called by `source mt-location` below.
+# The file 'mt-location' defines $mosesdirmine and is called by the `source` command below.
 
 # ***Login name*** of the user to whom the trained corpora will be transferred; ex: "john" (!!! you have to fill this parameter !!!)
 newusername=john
@@ -35,7 +35,7 @@ mosesdirotheruser="$HOME/Desktop/Machine-Translation/moses-irstlm-randlm"
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
 # The file 'mt-location' defines $mosesdirmine
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 # Register start date and time of corpus training 
 startdate=`date +day:%d/%m/%y-time:%H:%M:%S`
 #Base dir of trained corpora (before being transfered)

--- a/scripts/transfer-training-to-another-location-0.09
+++ b/scripts/transfer-training-to-another-location-0.09
@@ -25,8 +25,8 @@
 #####################################################################################
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
-# Base dir of the Moses system (e.g., $HOME/moses-irstlm-randlm) whose trainings you want to transfer to another location (!!! you have to fill this parameter !!!)
-mosesdirmine="$HOME/Desktop/Machine-Translation/MMM"
+# The file 'mt-location' defines $mosesdirmine and is called by `source mt-location` below.
+
 # ***Login name*** of the user to whom the trained corpora will be transferred; ex: "john" (!!! you have to fill this parameter !!!)
 newusername=john
 # Basedir of the Moses system to which the trained corpora will be transferred; ex: "/media/1.5TB/moses-irstlm-randlm"  (!!! you have to fill this parameter !!!)
@@ -34,7 +34,8 @@ mosesdirotheruser="$HOME/Desktop/Machine-Translation/moses-irstlm-randlm"
 ####################################################################################
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
-
+# The file 'mt-location' defines $mosesdirmine
+source mt-location
 # Register start date and time of corpus training 
 startdate=`date +day:%d/%m/%y-time:%H:%M:%S`
 #Base dir of trained corpora (before being transfered)

--- a/scripts/translate-1.38
+++ b/scripts/translate-1.38
@@ -38,8 +38,8 @@
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
 
-#Full path of the base directory of your Moses system 
-mosesdir="$HOME/Desktop/Machine-Translation/MMM"
+#Edit the file 'mt-location' to change $mosesdir for all scripts.
+source mt-location 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Even if you are using the demonstration corpus, you have to fill the $report_file parameter so that the script can be executed !!! 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/scripts/translate-1.38
+++ b/scripts/translate-1.38
@@ -38,8 +38,8 @@
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
 
-#Edit the file 'mt-location' to change $mosesdir for all scripts.
-source mt-location 
+#The file 'mt-location' defines $mosesdir for all scripts and is called by `source mt-location` below.
+
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Even if you are using the demonstration corpus, you have to fill the $report_file parameter so that the script can be executed !!! 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,6 +108,8 @@ distortionlimit=6
 ####################################################################################
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
+#The file 'mt-location' defines $mosesdir for all scripts.
+source mt-location
 
 startdate=`date +day:%d/%m/%y-time:%H:%M:%S`
 a=$0

--- a/scripts/translate-1.38
+++ b/scripts/translate-1.38
@@ -38,7 +38,7 @@
 # The values of the variables that follow should be filled according to your needs:
 #####################################################################################
 
-#The file 'mt-location' defines $mosesdir for all scripts and is called by `source mt-location` below.
+#The file 'mt-location' defines $mosesdir for all scripts and is called by the `source` command below.
 
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # Even if you are using the demonstration corpus, you have to fill the $report_file parameter so that the script can be executed !!! 
@@ -109,7 +109,7 @@ distortionlimit=6
 # DON'T CHANGE THE LINES THAT FOLLOW ... unless you know what you are doing!
 ####################################################################################
 #The file 'mt-location' defines $mosesdir for all scripts.
-source mt-location
+source $( cd $(dirname $0) ; pwd -P )/mt-location
 
 startdate=`date +day:%d/%m/%y-time:%H:%M:%S`
 a=$0


### PR DESCRIPTION
Install in a non-default location simply by changing a single file, `mt-location`.  This should make Chapter 10 of the Tutorial more user-friendly and less error-prone.

To-do
- Error checking (does `$mtdir` exist? etc.)
- Maybe determine `$mosesdir` directly from the directory structure, e.g., `mtdir=$(readlink -f $(pwd)/../..)`, and then tell users not to modify `mt-location` at all
- Update script modification dates in comments...version numbers too?
- Update Chapter 10 of Tutorial.pdf 
- Add `mosesdirmine=$mosesdir` to `mt-location`? I left the `transfer` script unchanged because the Chapter 10 only said to modify `$mosesdir` and `$MMMdir`, but glancing at Chapter 11, it seems like this might be okay...

Thank you!
